### PR TITLE
fix: only run `ct install` if chart changed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,4 +40,5 @@ jobs:
       if: steps.list-changed.outputs.changed == 'true'
 
     - name: Run chart-testing (install)
+      if: steps.list-changed.outputs.changed == 'true'
       run: ct install --all --chart-dirs charts


### PR DESCRIPTION
`ct install` should not be executed if no change is present - also no kind cluster will be available..