### PR TITLE
fix: specify branch to push release wf commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
     - name: commit version bump
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
+        branch: main
         commit_message: "chore(release): update version to ${{ github.event.release.tag_name }}"
         commit_options: "--no-verify"
         file_pattern: charts/ipsec-vpn-server/Chart.yaml


### PR DESCRIPTION
specify branch to push release wf commit - [v1.2.1 failed](https://github.com/taskmedia/helm_ipsec-vpn-server/actions/runs/3855671391/jobs/6570969701)

> INPUT_PUSH_OPTIONS: 
> fatal: You are not currently on a branch.
> To push the history leading to the current (detached HEAD)
> state now, use
> 
>     git push origin HEAD:<name-of-remote-branch>
> 
> Error: Invalid status code: 128
>     at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/index.js:17:19)
>     at ChildProcess.emit (node:events:[39](https://github.com/taskmedia/helm_ipsec-vpn-server/actions/runs/3855671391/jobs/6570969701#step:5:40)0:28)
>     at maybeClose (node:internal/child_process:1064:16)
>     at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5) {
>   code: 128
> }
> Error: Invalid status code: 128
>     at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/index.js:17:19)
>     at ChildProcess.emit (node:events:390:28)
>     at maybeClose (node:internal/child_process:1064:16)
>     at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5)