### PR TITLE
chore: use GITHUB_OUTPUT than set-output

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
         if [[ -n "$changed" ]]; then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Run chart-testing (lint)


### PR DESCRIPTION
see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/