### PR TITLE
fix: skip version-increment check on testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,10 @@ jobs:
         fi
 
     - name: Run chart-testing (lint)
-      run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+      run: |
+        ct lint \
+          --check-version-increment=false \
+          --target-branch ${{ github.event.repository.default_branch }}
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.4.0


### PR DESCRIPTION
The version incrementation is done by the release - no need to test this.
Otherwise the check will fail.