### PR TITLE
feat: add PersistentVolumeClaims for IPsec VPN Server

### DIFF
--- a/charts/ipsec-vpn-server/templates/deployment.yaml
+++ b/charts/ipsec-vpn-server/templates/deployment.yaml
@@ -59,8 +59,7 @@ spec:
 
       volumes:
         - name: vpn-config
-          persistentVolumeClaim:
-            claimName: {{ include "ipsec-vpn-server.fullname" . }}-config
+          emptyDir: {}
         - name: vpn-script
           configMap:
             name: {{ include "ipsec-vpn-server.fullname" . }}-vpnscript

--- a/charts/ipsec-vpn-server/templates/deployment.yaml
+++ b/charts/ipsec-vpn-server/templates/deployment.yaml
@@ -54,11 +54,17 @@ spec:
           volumeMounts:
             - mountPath: /opt/src/env/
               name: vpn-config
+            - mountPath: /etc/ipsec.d/
+              name: ipsec-data
 
       volumes:
         - name: vpn-config
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: {{ include "ipsec-vpn-server.fullname" . }}-config
         - name: vpn-script
           configMap:
             name: {{ include "ipsec-vpn-server.fullname" . }}-vpnscript
             defaultMode: 0777
+        - name: ipsec-data
+          persistentVolumeClaim:
+            claimName: {{ include "ipsec-vpn-server.fullname" . }}-data

--- a/charts/ipsec-vpn-server/templates/pvc.yaml
+++ b/charts/ipsec-vpn-server/templates/pvc.yaml
@@ -10,16 +10,3 @@ spec:
   resources:
       requests:
           storage: 10Mi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "ipsec-vpn-server.fullname" . }}-config
-  labels:
-      app.kubernetes.io/name: {{ template "ipsec-vpn-server.fullname" . }}-vpn-server
-spec:
-  accessModes:
-      - ReadWriteOnce
-  resources:
-      requests:
-          storage: 10Mi

--- a/charts/ipsec-vpn-server/templates/pvc.yaml
+++ b/charts/ipsec-vpn-server/templates/pvc.yaml
@@ -9,7 +9,7 @@ spec:
       - ReadWriteOnce
   resources:
       requests:
-          storage: 1Gi
+          storage: 10Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/ipsec-vpn-server/templates/pvc.yaml
+++ b/charts/ipsec-vpn-server/templates/pvc.yaml
@@ -22,4 +22,4 @@ spec:
       - ReadWriteOnce
   resources:
       requests:
-          storage: 1Gi
+          storage: 10Mi

--- a/charts/ipsec-vpn-server/templates/pvc.yaml
+++ b/charts/ipsec-vpn-server/templates/pvc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ipsec-vpn-server.fullname" . }}-data
+  labels:
+      app.kubernetes.io/name: {{ template "ipsec-vpn-server.fullname" . }}-vpn-server
+spec:
+  accessModes:
+      - ReadWriteOnce
+  resources:
+      requests:
+          storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ipsec-vpn-server.fullname" . }}-config
+  labels:
+      app.kubernetes.io/name: {{ template "ipsec-vpn-server.fullname" . }}-vpn-server
+spec:
+  accessModes:
+      - ReadWriteOnce
+  resources:
+      requests:
+          storage: 1Gi


### PR DESCRIPTION
This pull request adds PersistentVolumeClaims (PVCs) to the IPsec VPN Server chart to provide persistent storage for configuration and data volumes. This allows for the persistence of configuration data and IPsec-related data across pod restarts.