### PR TITLE
chore: allow to specify initContainer image via values

### DIFF
--- a/charts/ipsec-vpn-server/templates/deployment.yaml
+++ b/charts/ipsec-vpn-server/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: init-config
-          image: bash:alpine3.15
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           command: ["sh", "-c"]
           args: ["/vpn/scripts/create-env.sh"]
           env:

--- a/charts/ipsec-vpn-server/values.yaml
+++ b/charts/ipsec-vpn-server/values.yaml
@@ -6,6 +6,11 @@ image:
   tag: latest
   pullPolicy: Always
 
+initContainer:
+  image:
+    repository: bash
+    tag: alpine3.15
+
 sealed_secrets: false
 
 vpn:


### PR DESCRIPTION
Allow to specify a initContainer image and tag via values.yaml