### PR TITLE
chore: use traefik.io for ingressrouteudp

### DIFF
--- a/charts/ipsec-vpn-server/templates/ingress/traefik/ingressrouteudp.yaml
+++ b/charts/ipsec-vpn-server/templates/ingress/traefik/ingressrouteudp.yaml
@@ -1,7 +1,7 @@
 {{- $fullname_vpn_server := (printf "%s-vpn-server" (include "ipsec-vpn-server.fullname" .)) -}}
 {{- if .Values.ingress.traefik.enabled }}
 {{- range .Values.service.ports }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteUDP
 metadata:
   name: {{ $fullname_vpn_server }}-{{ .name }}


### PR DESCRIPTION
Updating to `traefik.io/v1alpha1` as old CRD version was deprecated long time ago...